### PR TITLE
Adding support of filtering cases for adding in TestRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const testrailUtil = require('wdio-wdiov5testrail-reporter/lib');
 | strictCaseMatching | false to NOT throw an error if a test case found is not apart of the suite.  Defaults to true. |
 | skippedStatusId | A custom status id assigned to skipped tests.  If not assigned, skipped tests will be marked as status 4. |
 | closeTestRailRun | true to close test run in Test Rail after tests are complete.  Defaults to false. | 
-| casesFieldFilter | A {key:value} object to filter cases added to the test run, e.g. {'priority_id': 1, 'type_id': 2}. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases |
+| casesFieldFilter | A `{key: value}` object to filter cases added to the test run, e.g. `{'priority_id': 1, 'type_id': 2}`. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases |
 
 ### Prefix all test assertions you wish to map with the test number.
 Include the letter C.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const testrailUtil = require('wdio-wdiov5testrail-reporter/lib');
 | strictCaseMatching | false to NOT throw an error if a test case found is not apart of the suite.  Defaults to true. |
 | skippedStatusId | A custom status id assigned to skipped tests.  If not assigned, skipped tests will be marked as status 4. |
 | closeTestRailRun | true to close test run in Test Rail after tests are complete.  Defaults to false. | 
-| casesFieldFilter | A `{key: value}` object to filter cases added to the test run, e.g. `{'priority_id': 1, 'type_id': 2}`. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases |
+| casesFieldFilter | A `{key: value}` object to filter cases added to the test run, e.g. `{'priority_id': 1, 'type_id': 2}`. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases. `NOTE: if you use multiple key:value pairs in the filter object it will work as AND conditions.` |
 
 ### Prefix all test assertions you wish to map with the test number.
 Include the letter C.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ const testrailUtil = require('wdio-wdiov5testrail-reporter/lib');
 | includeAll | true to include all tests in run, regardless of whether actually run by Webdriver.io.  Defaults to true. |
 | strictCaseMatching | false to NOT throw an error if a test case found is not apart of the suite.  Defaults to true. |
 | skippedStatusId | A custom status id assigned to skipped tests.  If not assigned, skipped tests will be marked as status 4. |
-| closeTestRailRun: | true to close test run in Test Rail after tests are complete.  Defaults to false. | 
+| closeTestRailRun | true to close test run in Test Rail after tests are complete.  Defaults to false. | 
+| casesFieldFilter | A {key:value} object to filter cases added to the test run, e.g. {'priority_id': 1, 'type_id': 2}. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases |
 
 ### Prefix all test assertions you wish to map with the test number.
 Include the letter C.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const testrailUtil = require('wdio-wdiov5testrail-reporter/lib');
 | strictCaseMatching | false to NOT throw an error if a test case found is not apart of the suite.  Defaults to true. |
 | skippedStatusId | A custom status id assigned to skipped tests.  If not assigned, skipped tests will be marked as status 4. |
 | closeTestRailRun | true to close test run in Test Rail after tests are complete.  Defaults to false. | 
-| casesFieldFilter | A `{key: value}` object to filter cases added to the test run, e.g. `{'priority_id': 1, 'type_id': 2}`. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases. `NOTE: if you use multiple key:value pairs in the filter object it will work as AND conditions.` |
+| casesFieldFilter | A `{key: value}` object to filter cases added to the test run, e.g. `{'priority_id': 1, 'type_id': 2}`. Values should be taken from TestRails. Running with empty value or with missing `closeTestRailRun` option will return a full list of cases. `NOTE 1: if you use multiple key:value pairs in the filter object it will work as AND conditions.` `NOTE 2: casesFieldFilter takes into account only if includeAll=false`|
 
 ### Prefix all test assertions you wish to map with the test number.
 Include the letter C.

--- a/src/testrailApi.js
+++ b/src/testrailApi.js
@@ -57,7 +57,7 @@ class TestRailApi {
   /** *
    * Unlike other methods in this class, returns an array of cases rather than a response object.
    */
-   getCases() {
+  getCases() {
     let cases = [];
     const {
       projectId, 

--- a/src/util.js
+++ b/src/util.js
@@ -65,7 +65,7 @@ module.exports.cleanup = function cleanup(config) {
     planId = JSON.parse(response.getBody()).id;
   }
   
-  const actualCaseIds = [];
+  let actualCaseIds = [];
   
   groupedResults.forEach((resultSet) => {
     let results = [...resultSet];
@@ -144,8 +144,13 @@ module.exports.cleanup = function cleanup(config) {
       if (options.includeAll === false) {
         json.include_all = false;
         if (options.casesFieldFilter) {
-          // taking actualCaseIds in case if it has been already fetched or fetch filtered list of cases
-          json.case_ids = actualCaseIds.length ? actualCaseIds : testrail.getCases();
+          if (!actualCaseIds.length) {
+            // fetch filtered list of cases
+            actualCaseIds = testrail.getCases();
+          }
+          json.case_ids = actualCaseIds;
+          // leave only results for filtered cases
+          results = resultSet.filter(result => actualCaseIds.includes(Number.parseInt(result.case_id, 10)));
         } else {
           json.case_ids = results.map((currentResult) => currentResult.case_id);
         }

--- a/src/util.js
+++ b/src/util.js
@@ -135,16 +135,15 @@ module.exports.cleanup = function cleanup(config) {
       response = testrail.getRuns();
       options.runId = JSON.parse(response.getBody()).runs[0].id;
     } else if (!options.runId || createTestPlan) {
-      // will include all actual cases fetched above
       const json = {
         name: createTestPlan ? resultSet[0].browserName : options.title,
         suite_id: options.suiteId,
         description
       };
-      // will include only cases with results
       if (options.includeAll === false) {
         json.include_all = false;
         if (options.casesFieldFilter) {
+          // including only filtered cases
           json.case_ids = actualCaseIds;
         } else {
           json.case_ids = results.map((currentResult) => currentResult.case_id);

--- a/src/util.js
+++ b/src/util.js
@@ -71,7 +71,8 @@ module.exports.cleanup = function cleanup(config) {
     let results = [...resultSet];
     if (
       options.strictCaseMatching !== undefined &&
-      options.strictCaseMatching !== true
+      options.strictCaseMatching !== true ||
+      options.casesFieldFilter
     ) {
       actualCaseIds = testrail.getCases();
       results = resultSet.filter((result) =>
@@ -144,13 +145,7 @@ module.exports.cleanup = function cleanup(config) {
       if (options.includeAll === false) {
         json.include_all = false;
         if (options.casesFieldFilter) {
-          if (!actualCaseIds.length) {
-            // fetch filtered list of cases
-            actualCaseIds = testrail.getCases();
-          }
           json.case_ids = actualCaseIds;
-          // leave only results for filtered cases
-          results = resultSet.filter(result => actualCaseIds.includes(Number.parseInt(result.case_id, 10)));
         } else {
           json.case_ids = results.map((currentResult) => currentResult.case_id);
         }


### PR DESCRIPTION
Current implementation of library supports only creation of test runs for all tests in project and suite. There were no possibility for apply more filters. 
With this PR you will be able to create smaller TestRuns based on custom filters: only hight priority cases, only specific test types and etc. Even if you add a custom field, e.g. Responsible Team, it will be possible to use this custom value in the filter.

Example: 
```
reporters: [
    ['wdiov5testrail', {
      domain: 'your domain',
      username: 'your testrail username',
      password: 'your testrail password (or api key)',
      projectId: your testrail project id,
      casesFieldFilter: {'priority_id': 1, 'type_id': 2}
    }],
  ],
```

`NOTE: if you use multiple key:value pairs in the filter object it will work as AND conditions.`