### PR TITLE
Including in "strictCaseMatching" option opportunity to check matching of cases for custom test runs

### DIFF
--- a/src/testrailApi.js
+++ b/src/testrailApi.js
@@ -91,6 +91,26 @@ class TestRailApi {
     return cases;
   }
 
+  getCasesFromTestRun() {
+    let cases = [];
+
+    let response = null;
+    let nextUrl = `get_tests/${this.options.runId}`;
+    do {
+      response = JSON.parse(this.get(nextUrl).getBody());
+      const currentCases = response.tests.map((testCase) => testCase.case_id);
+      cases = cases.concat(currentCases);
+
+      nextUrl = response._links.next
+        ? response._links.next.substring(
+            response._links.next.indexOf('get_tests'),
+          )
+        : null;
+    } while (nextUrl);
+
+    return cases;
+  }
+
   addPlan() {
     return this.post(`add_plan/${this.options.projectId}`, {
       name: this.options.title,

--- a/src/util.js
+++ b/src/util.js
@@ -64,9 +64,9 @@ module.exports.cleanup = function cleanup(config) {
     response = testrail.addPlan();
     planId = JSON.parse(response.getBody()).id;
   }
-  
+
   let actualCaseIds = [];
-  
+
   groupedResults.forEach((resultSet) => {
     let results = [...resultSet];
     if (
@@ -74,7 +74,11 @@ module.exports.cleanup = function cleanup(config) {
       options.strictCaseMatching !== true ||
       options.casesFieldFilter
     ) {
-      actualCaseIds = testrail.getCases();
+      if (options.runId === undefined) {
+        actualCaseIds = testrail.getCases();
+      } else {
+        actualCaseIds = testrail.getCasesFromTestRun();
+      }
       results = resultSet.filter((result) =>
         actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );


### PR DESCRIPTION
Current implementation of "strictCaseMatching" support handling only one type of error - "_if a test case found is not apart of the suite_". But in practice, sometimes we have situations when we need to export to already created test run our test results, which includes cases not part of the test run . And instead of just skipping such results testrailApi show error like:

> {"error":"Field :results contains one or more invalid results (case C5534 unknown or not part of the test run)"}

This PR solves this problem by adding a new testRail request (/api/v2/get_tests/runId).