### PR TITLE
Log Invalid Tests on strictCaseMatching value as true

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class CustomReporter extends WDIOReporter {
 
   onTestEnd(test) {
     const strings = test.title.split(' ');
-    const testCaseRegex = /\bC(\d+)\b/;
+    const testCaseRegex = /\bC(\d+)\b/i;
 
     strings.forEach((string) => {
       const matches = string.match(testCaseRegex);

--- a/src/util.js
+++ b/src/util.js
@@ -87,9 +87,7 @@ module.exports.cleanup = function cleanup(config) {
         !actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );
 
-      let invalidTestCases = [];
-      invalidFilteredTests.forEach(result => invalidTestCases.push(result.case_id));
-      console.log(`Invalid Test Cases - ${invalidTestCases}`);
+      if (invalidFilteredTests.length > 0) console.log(`Invalid Test Cases - ${invalidFilteredTests.map(test => test.case_id)}`);
     }
     const passing = results.reduce(
       (total, currentResult) =>

--- a/src/util.js
+++ b/src/util.js
@@ -82,15 +82,6 @@ module.exports.cleanup = function cleanup(config) {
       results = resultSet.filter((result) =>
         actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );
-    } else if (options.strictCaseMatching === true) {
-      if (options.runId === undefined) {
-        actualCaseIds = testrail.getCases();
-      } else {
-        actualCaseIds = testrail.getCasesFromTestRun();
-      }
-      results = resultSet.filter((result) =>
-        actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
-      );
 
       const invalidFilteredTests = resultSet.filter((result) =>
         !actualCaseIds.includes(Number.parseInt(result.case_id, 10)),

--- a/src/util.js
+++ b/src/util.js
@@ -83,7 +83,11 @@ module.exports.cleanup = function cleanup(config) {
         actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );
     } else if (options.strictCaseMatching === true) {
-      actualCaseIds = testrail.getCases();
+      if (options.runId === undefined) {
+        actualCaseIds = testrail.getCases();
+      } else {
+        actualCaseIds = testrail.getCasesFromTestRun();
+      }
       results = resultSet.filter((result) =>
         actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );

--- a/src/util.js
+++ b/src/util.js
@@ -82,6 +82,19 @@ module.exports.cleanup = function cleanup(config) {
       results = resultSet.filter((result) =>
         actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
       );
+    } else if (options.strictCaseMatching === true) {
+      actualCaseIds = testrail.getCases();
+      results = resultSet.filter((result) =>
+        actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
+      );
+
+      const invalidFilteredTests = resultSet.filter((result) =>
+        !actualCaseIds.includes(Number.parseInt(result.case_id, 10)),
+      );
+
+      let invalidTestCases = [];
+      invalidFilteredTests.forEach(result => invalidTestCases.push(result.case_id));
+      console.log(`Invalid Test Cases - ${invalidTestCases}`);
     }
     const passing = results.reduce(
       (total, currentResult) =>


### PR DESCRIPTION
We have logged an issue for logging of invalid tests when strictCaseMatching value as true
https://github.com/billylam/wdio-wdiov5testrail-reporter/issues/20